### PR TITLE
fix: add npm metadata links

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   "bin": {
     "bnbchain-mcp": "./dist/index.js"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "publishConfig": {
     "access": "public"
   },
@@ -43,5 +45,15 @@
     "typescript": "^5.0.0"
   },
   "license": "MIT",
-  "trustedDependencies": ["@biomejs/biome"]
+  "trustedDependencies": [
+    "@biomejs/biome"
+  ],
+  "homepage": "https://github.com/bnb-chain/bnbchain-mcp#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bnb-chain/bnbchain-mcp.git"
+  },
+  "bugs": {
+    "url": "https://github.com/bnb-chain/bnbchain-mcp/issues"
+  }
 }


### PR DESCRIPTION
## Summary
- Add npm `homepage`, `repository`, and `bugs` metadata for `@bnb-chain/mcp`.
- Point registry consumers to this public source repository and issue tracker.

## Verification
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('bnb chain package json valid')"`
- `npm pack --dry-run --json --ignore-scripts`

## Note
The currently published npm version is `1.5.1`, while this public source manifest is `0.0.1`. This PR updates the public source metadata for the next publish from this repository.

No wallet, payment, private-key, API credential, balance, order, transfer, signing, or transaction code paths were run; this is a package metadata-only change.
